### PR TITLE
Prevents unlearn from being used from a private message. Fixes #13

### DIFF
--- a/system.go
+++ b/system.go
@@ -63,6 +63,7 @@ type StringMap interface {
 // message handler.
 type DiscordSession interface {
 	ChannelMessageSend(channel, message string) (*discordgo.Message, error)
+	Channel(channelID string) (*discordgo.Channel, error)
 }
 
 // Gist is a wrapper around a simple Gist uploader. Returns the URL on success.

--- a/system_test.go
+++ b/system_test.go
@@ -125,6 +125,14 @@ func Test_Integration(t *testing.T) {
 	customMap := util.NewInMemoryStringMap()
 	gist := util.NewInMemoryGist()
 	discordSession := util.NewInMemoryDiscordSession()
+	discordSession.SetChannel(&discordgo.Channel{
+		ID:        "channel",
+		IsPrivate: false,
+	})
+	discordSession.SetChannel(&discordgo.Channel{
+		ID:        "literally anything else",
+		IsPrivate: true,
+	})
 
 	registry := InitializeRegistry(customMap, gist)
 	runner := &TestRunner{
@@ -222,6 +230,8 @@ func Test_Integration(t *testing.T) {
 	runner.SendMessage("channel", "?unlearn", MsgHelpUnlearn)
 	runner.SendMessage("channel", "?unlearn ", MsgHelpUnlearn)
 	runner.SendMessage("channel", "?unlearn  bears", MsgHelpUnlearn)
+	// Can't unlearn in a private channel
+	runner.SendMessage("literally anything else", "?unlearn call", MsgUnlearnMustBePublic)
 	// Can't unlearn builtin commands.
 	runner.SendMessage("channel", "?unlearn help", fmt.Sprintf(MsgUnlearnFail, "help"))
 	runner.SendMessage("channel", "?unlearn learn", fmt.Sprintf(MsgUnlearnFail, "learn"))

--- a/unlearnfeature.go
+++ b/unlearnfeature.go
@@ -93,12 +93,13 @@ func (f *UnlearnFeature) Execute(s DiscordSession, channel string, command *Comm
 
 	// Get the current channel and check if we're being asked to unlearn in a
 	// private message.
-	c, err := s.Channel(channel)
+	discordChannel, err := s.Channel(channel)
 	if err != nil {
 		fatal("This message didn't come from a valid channel", errors.New("wat"))
 	}
-	if c.IsPrivate {
+	if discordChannel.IsPrivate {
 		s.ChannelMessageSend(channel, MsgUnlearnMustBePublic)
+		return
 	}
 
 	if !command.Unlearn.CallOpen {

--- a/util/discordsession.go
+++ b/util/discordsession.go
@@ -1,6 +1,10 @@
 package util
 
-import "github.com/bwmarrin/discordgo"
+import (
+	"errors"
+
+	"github.com/bwmarrin/discordgo"
+)
 
 // Message encapsulates a channel/message pair.
 type Message struct {
@@ -19,14 +23,17 @@ func NewMessage(channel, message string) *Message {
 // InMemoryDiscordSession is a fake for the discord session.
 type InMemoryDiscordSession struct {
 	Messages  []*Message
+	Channels  map[string]*discordgo.Channel
 	currentID int
 	author    *discordgo.User
 }
 
 // NewInMemoryDiscordSession works as advertised.
 func NewInMemoryDiscordSession() *InMemoryDiscordSession {
+	channels := make(map[string]*discordgo.Channel)
 	return &InMemoryDiscordSession{
 		Messages:  []*Message{},
+		Channels:  channels,
 		currentID: 0,
 		author: &discordgo.User{
 			"bot_id",
@@ -65,6 +72,15 @@ func (s *InMemoryDiscordSession) ChannelMessageSend(channel, message string) (*d
 // Channel returns the Channel struct of the given channel ID. Can be used to
 // determine attributes such as the channel name, topic, etc.
 func (s *InMemoryDiscordSession) Channel(channelID string) (*discordgo.Channel, error) {
-	// TODO: Implement logic for what should be returned here, with respect to tests.
-	return new(discordgo.Channel), nil
+	if channel := s.Channels[channelID]; channel != nil {
+		return channel, nil
+	}
+	return nil, errors.New("Attempted to get missing channel " + channelID)
+}
+
+// SetChannel adds a channel to the map of channels that InMemoryDiscordSession
+// holds. Can be used to test features that only work under certain channel
+// conditions.
+func (s *InMemoryDiscordSession) SetChannel(channel *discordgo.Channel) {
+	s.Channels[channel.ID] = channel
 }

--- a/util/discordsession.go
+++ b/util/discordsession.go
@@ -61,3 +61,10 @@ func (s *InMemoryDiscordSession) ChannelMessageSend(channel, message string) (*d
 		Reactions:       []*discordgo.MessageReactions{},
 	}, nil
 }
+
+// Channel returns the Channel struct of the given channel ID. Can be used to
+// determine attributes such as the channel name, topic, etc.
+func (s *InMemoryDiscordSession) Channel(channelID string) (*discordgo.Channel, error) {
+	// TODO: Implement logic for what should be returned here, with respect to tests.
+	return new(discordgo.Channel), nil
+}


### PR DESCRIPTION
I had to make a few additions outside of the original comment I made - namely, I had to expand the DiscordSession interface to have a Channel function. In order to not break testing, I added a stub function to the in memory discord session, but it currently doesn't return anything useful. 

Builds and passes tests, but I haven't tried this in a real Discord channel.