### PR TITLE
Removed single line mode on call regex, to prevent multi-line call names. Fixes #16

### DIFF
--- a/learnfeature.go
+++ b/learnfeature.go
@@ -42,7 +42,7 @@ func (f *LearnFeature) Parse(splitContent []string) (*Command, error) {
 		fatal("parseLearn called with non-learn command", errors.New("wat"))
 	}
 
-	callRegexp := regexp.MustCompile("(?s)^[[:alnum:]].*$")
+	callRegexp := regexp.MustCompile("^[[:alnum:]].*$")
 	responseRegexp := regexp.MustCompile("(?s)^[^/?!].*$")
 
 	// Show help when not enough data is present, or malicious data is present.

--- a/system_test.go
+++ b/system_test.go
@@ -180,6 +180,7 @@ func Test_Integration(t *testing.T) {
 	runner.SendMessage("channel", "?learn /call response", MsgHelpLearn)
 	runner.SendMessage("channel", "?learn  call response", MsgHelpLearn)
 	runner.SendMessage("channel", "?learn ", MsgHelpLearn)
+	runner.SendMessage("channel", "?learn multi\nline\ncall response", MsgHelpLearn)
 	// Wrong response format.
 	runner.SendMessage("channel", "?learn call ?response", MsgHelpLearn)
 	runner.SendMessage("channel", "?learn call !response", MsgHelpLearn)

--- a/unlearnfeature.go
+++ b/unlearnfeature.go
@@ -41,7 +41,7 @@ func (f *UnlearnFeature) Parse(splitContent []string) (*Command, error) {
 		fatal("parseUnlearn called with non-unlearn command", errors.New("wat"))
 	}
 
-	callRegexp := regexp.MustCompile("(?s)^[[:alnum:]].*$")
+	callRegexp := regexp.MustCompile("^[[:alnum:]].*$")
 
 	// Show help when not enough data is present, or malicious data is present.
 	if len(splitContent) < 2 || !callRegexp.MatchString(splitContent[1]) {


### PR DESCRIPTION
The call regex had single line mode enabled, which according to the Go regex docs:

```
Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). The flags are:

i              case-insensitive (default false)
m              multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false)
s              let . match \n (default false)
U              ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false)
```
This fix removes single line mode for the call in both learn and unlearn.

I also added a test case for this to catch regressions in the future.