### PR TITLE
raise the number of replacements from 1 to 4

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Jake Voytko
 Ryan Van Antwerp
+Andrew E. Timmes

--- a/learnfeature.go
+++ b/learnfeature.go
@@ -391,7 +391,7 @@ func (e *CustomExecutor) Execute(s DiscordSession, channel string, command *Comm
 		if command.Custom.Args == "" {
 			response = MsgCustomNeedsArgs
 		} else {
-			response = strings.Replace(response, "$1", command.Custom.Args, 1)
+			response = strings.Replace(response, "$1", command.Custom.Args, 4)
 		}
 	}
 	s.ChannelMessageSend(channel, response)

--- a/system_test.go
+++ b/system_test.go
@@ -195,6 +195,7 @@ func Test_Integration(t *testing.T) {
 	runner.SendLearnMessage("channel", "?learn args1 hello $1", NewLearn("args1", "hello $1"))
 	runner.SendLearnMessage("channel", "?learn args2 $1", NewLearn("args2", "$1"))
 	runner.SendLearnMessage("channel", "?learn args3 $1 $1", NewLearn("args3", "$1 $1"))
+	runner.SendLearnMessage("channel", "?learn args4 $1 $1 $1 $1 $1", NewLearn("args4", "$1 $1 $1 $1 $1"))
 	// Cannot overwrite a learn.
 	runner.SendMessage("channel", "?learn call response", fmt.Sprintf(MsgLearnFail, "call"))
 	// List should now include learns.
@@ -213,8 +214,11 @@ func Test_Integration(t *testing.T) {
 	runner.SendMessage("channel", "?emoji", "⛄⛄⛄⛄")
 	runner.SendMessage("channel", "?args1 world", "hello world")
 	runner.SendMessage("channel", "?args2 world", "world")
-	runner.SendMessage("channel", "?args3 world", "world $1")
-	runner.SendMessage("channel", "?args3     leadingspaces", "    leadingspaces $1")
+	runner.SendMessage("channel", "?args3 world", "world world")
+	runner.SendMessage("channel", "?args3     leadingspaces", "    leadingspaces     leadingspaces")
+	runner.SendMessage("channel", "?args4 world", "world world world world $1")
+        runner.SendMessage("channel", "?args4     leadingspaces", "    leadingspaces     leadingspaces     leadingspaces     leadingspaces $1")
+
 	runner.SendMessage("channel", "?args1", MsgCustomNeedsArgs)
 	runner.SendMessage("channel", "?spaceBeforeCall", "response")
 	runner.SendMessage("channel", "?spaceBeforeResponse", "response")
@@ -344,7 +348,7 @@ func assertNewMessages(t *testing.T, discordSession *util.InMemoryDiscordSession
 	for i := 0; i < len(newMessages); i++ {
 		actualMessage := discordSession.Messages[len(discordSession.Messages)-len(newMessages)+i]
 		if !reflect.DeepEqual(newMessages[i], actualMessage) {
-			t.Errorf("Expected message %v channel %v, got message %v channel %v",
+			t.Errorf("Expected message \n '%v' \n on channel '%v', got message \n '%v' \n on channel '%v'",
 				newMessages[i].Message,
 				newMessages[i].Channel,
 				actualMessage.Message,


### PR DESCRIPTION
This allows for a slightly larger yet finite number of replacements, allowing for the flexibility to enable ?rlspam.