### PR TITLE
Pulls the public-only checks out of executors, and puts it as a flag on Executor

### DIFF
--- a/feature/executor.go
+++ b/feature/executor.go
@@ -11,4 +11,6 @@ type Executor interface {
 	GetType() int
 	// Execute the given command, for the session and channel name provided.
 	Execute(api.DiscordSession, model.Snowflake, *model.Command)
+	// Whether the command cannot be executed in private channels.
+	PublicOnly() bool
 }

--- a/feature/help/helpexecutor.go
+++ b/feature/help/helpexecutor.go
@@ -30,6 +30,11 @@ func (e *HelpExecutor) GetType() int {
 	return model.Type_Help
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *HelpExecutor) PublicOnly() bool {
+	return false
+}
+
 // Execute replies over the given channel with a help message.
 func (e *HelpExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	if command.Help == nil {

--- a/feature/learn/customexecutor.go
+++ b/feature/learn/customexecutor.go
@@ -22,6 +22,11 @@ func (e *CustomExecutor) GetType() int {
 	return model.Type_Custom
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *CustomExecutor) PublicOnly() bool {
+	return false
+}
+
 // Execute returns the response if possible.
 func (e *CustomExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	if command.Custom == nil {

--- a/feature/learn/learnexecutor.go
+++ b/feature/learn/learnexecutor.go
@@ -24,6 +24,11 @@ func (f *LearnExecutor) GetType() int {
 	return model.Type_Learn
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *LearnExecutor) PublicOnly() bool {
+	return false
+}
+
 // Execute replies over the given channel with a help message.
 func (f *LearnExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	if command.Learn == nil {

--- a/feature/learn/unlearnexecutor.go
+++ b/feature/learn/unlearnexecutor.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/bwmarrin/discordgo"
 	"github.com/jakevoytko/crbot/api"
 	"github.com/jakevoytko/crbot/log"
 	"github.com/jakevoytko/crbot/model"
@@ -23,22 +22,16 @@ func (f *UnlearnExecutor) GetType() int {
 	return model.Type_Unlearn
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *UnlearnExecutor) PublicOnly() bool {
+	return true
+}
+
 // Execute replies over the given channel indicating successful unlearning, or
 // failure to unlearn.
 func (e *UnlearnExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	if command.Unlearn == nil {
 		log.Fatal("Incorrectly generated unlearn command", errors.New("wat"))
-	}
-
-	// Get the current channel and check if we're being asked to unlearn in a
-	// private message.
-	discordChannel, err := s.Channel(channel.Format())
-	if err != nil {
-		log.Fatal("This message didn't come from a valid channel", errors.New("wat"))
-	}
-	if discordChannel.Type == discordgo.ChannelTypeDM || discordChannel.Type == discordgo.ChannelTypeGroupDM {
-		s.ChannelMessageSend(channel.Format(), MsgUnlearnMustBePublic)
-		return
 	}
 
 	if !command.Unlearn.CallOpen {

--- a/feature/list/listexecutor.go
+++ b/feature/list/listexecutor.go
@@ -36,6 +36,11 @@ func (e *ListExecutor) GetType() int {
 	return model.Type_List
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *ListExecutor) PublicOnly() bool {
+	return false
+}
+
 // Execute uploads the command list to github and pings the gist link in chat.
 func (e *ListExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	builtins := e.featureRegistry.GetInvokableFeatureNames()

--- a/feature/moderation/ricklistexecutor.go
+++ b/feature/moderation/ricklistexecutor.go
@@ -24,6 +24,11 @@ func (e *RickListExecutor) GetType() int {
 	return model.Type_RickList
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *RickListExecutor) PublicOnly() bool {
+	return false
+}
+
 // Execute replies over the given channel with a rick roll.
 func (e *RickListExecutor) Execute(s api.DiscordSession, channel model.Snowflake, command *model.Command) {
 	if _, err := s.ChannelMessageSend(channel.Format(), MsgRickList); err != nil {

--- a/feature/moderation/ricklistinfoexecutor.go
+++ b/feature/moderation/ricklistinfoexecutor.go
@@ -27,6 +27,11 @@ func (e *RickListInfoExecutor) GetType() int {
 	return model.Type_RickListInfo
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *RickListInfoExecutor) PublicOnly() bool {
+	return false
+}
+
 const (
 	MsgRickListEmpty = "Nobody is on the ricklist."
 	MsgRickListUsers = "On the Rick list: "

--- a/feature/vote/BUILD.bazel
+++ b/feature/vote/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     srcs = glob(["*.go"]),
     deps = [
         "//api:go_default_library",
+        "//app:go_default_library",
         "//feature:go_default_library",
         "//log:go_default_library",
         "//model:go_default_library",

--- a/feature/vote/ballotexecutor.go
+++ b/feature/vote/ballotexecutor.go
@@ -1,11 +1,9 @@
 package vote
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/bwmarrin/discordgo"
 	"github.com/jakevoytko/crbot/api"
 	"github.com/jakevoytko/crbot/log"
 	"github.com/jakevoytko/crbot/model"
@@ -26,26 +24,21 @@ func (e *BallotExecutor) GetType() int {
 	return model.Type_VoteBallot
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *BallotExecutor) PublicOnly() bool {
+	return true
+}
+
 const (
-	MsgAlreadyVoted       = "%v already voted"
-	MsgVotedAgainst       = "%v voted no"
-	MsgVotedInFavor       = "%v voted yes"
-	MsgBallotMustBePublic = "Ballots can only be cast in public channels"
+	MsgAlreadyVoted = "%v already voted"
+	MsgVotedAgainst = "%v voted no"
+	MsgVotedInFavor = "%v voted yes"
 )
 
 func (e *BallotExecutor) Execute(s api.DiscordSession, channelID model.Snowflake, command *model.Command) {
 	userID, err := model.ParseSnowflake(command.Author.ID)
 	if err != nil {
 		log.Fatal("Error parsing discord user ID", err)
-	}
-
-	discordChannel, err := s.Channel(channelID.Format())
-	if err != nil {
-		log.Fatal("This message didn't come from a valid channel", errors.New("wat"))
-	}
-	if discordChannel.Type == discordgo.ChannelTypeDM || discordChannel.Type == discordgo.ChannelTypeGroupDM {
-		s.ChannelMessageSend(channelID.Format(), MsgBallotMustBePublic)
-		return
 	}
 
 	vote, err := e.modelHelper.CastBallot(channelID, userID, command.Ballot.InFavor)

--- a/feature/vote/concludeexecutor.go
+++ b/feature/vote/concludeexecutor.go
@@ -24,6 +24,14 @@ func (e *ConcludeExecutor) GetType() int {
 	return model.Type_VoteConclude
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private
+// channel. Since the vote is pinned to a channel, it should have been filtered
+// then. If somehow the channel went private at that point, allow it to
+// conclude.
+func (e *ConcludeExecutor) PublicOnly() bool {
+	return false
+}
+
 const (
 	MsgVoteConcluded = "@here -- Vote started by %s has concluded"
 )

--- a/feature/vote/feature_test.go
+++ b/feature/vote/feature_test.go
@@ -1,9 +1,11 @@
 package vote
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/jakevoytko/crbot/app"
 	"github.com/jakevoytko/crbot/testutil"
 )
 
@@ -218,4 +220,16 @@ func TestVote_CannotVoteTwice(t *testing.T) {
 	runner.CastBallotAs(author, testutil.MainChannelID, true /* inFavor */)
 	runner.CastDuplicateBallotAs(author, testutil.MainChannelID, true /* inFavor */)
 	runner.CastDuplicateBallotAs(author, testutil.MainChannelID, false /* inFavor */)
+}
+
+func TestVote_PrivateChannel(t *testing.T) {
+	runner := testutil.NewRunner(t)
+	author := testutil.NewUser("author", 0 /* id */, false /* bot */)
+	runner.AddUser(author)
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?vote asdf", fmt.Sprintf(app.MsgPublicOnly, "?vote"))
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?votestatus", fmt.Sprintf(app.MsgPublicOnly, "?votestatus"))
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?f1", fmt.Sprintf(app.MsgPublicOnly, "?f1"))
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?f2", fmt.Sprintf(app.MsgPublicOnly, "?f2"))
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?yes", fmt.Sprintf(app.MsgPublicOnly, "?yes"))
+	runner.SendMessageAs(author, testutil.DirectMessageID, "?no", fmt.Sprintf(app.MsgPublicOnly, "?no"))
 }

--- a/feature/vote/statusexecutor.go
+++ b/feature/vote/statusexecutor.go
@@ -25,6 +25,11 @@ func (e *StatusExecutor) GetType() int {
 	return model.Type_VoteStatus
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *StatusExecutor) PublicOnly() bool {
+	return true
+}
+
 const (
 	MsgNoActiveVote       = "No active vote"
 	MsgOneVoteAgainst     = "1 vote against"

--- a/feature/vote/voteexecutor.go
+++ b/feature/vote/voteexecutor.go
@@ -1,10 +1,8 @@
 package vote
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/bwmarrin/discordgo"
 	"github.com/jakevoytko/crbot/api"
 	"github.com/jakevoytko/crbot/log"
 	"github.com/jakevoytko/crbot/model"
@@ -29,24 +27,19 @@ func (e *VoteExecutor) GetType() int {
 	return model.Type_Vote
 }
 
+// PublicOnly returns whether the executor should be intercepted in a private channel.
+func (e *VoteExecutor) PublicOnly() bool {
+	return true
+}
+
 const (
 	MsgActiveVote       = "Cannot start a vote while another is in progress. Type `?votestatus` for more info"
 	MsgBroadcastNewVote = "@everyone -- %s started a new vote: %s\n\nType `?yes` or `?no` to vote. 30 minutes remaining."
-	MsgVoteMustBePublic = "Votes can only be started in public channels"
 )
 
 // Execute starts a new vote if one is not already active. It also starts a
 // timer to use to conclude the vote.
 func (e *VoteExecutor) Execute(s api.DiscordSession, channelID model.Snowflake, command *model.Command) {
-	discordChannel, err := s.Channel(channelID.Format())
-	if err != nil {
-		log.Fatal("This message didn't come from a valid channel", errors.New("wat"))
-	}
-	if discordChannel.Type == discordgo.ChannelTypeDM || discordChannel.Type == discordgo.ChannelTypeGroupDM {
-		s.ChannelMessageSend(channelID.Format(), MsgVoteMustBePublic)
-		return
-	}
-
 	ok, err := e.modelHelper.IsVoteActive(channelID)
 	if err != nil {
 		log.Fatal("Error occurred while calling for active vote", err)

--- a/model/command.go
+++ b/model/command.go
@@ -70,9 +70,10 @@ type BallotData struct {
 // TODO(jake): Make this an interface that has only getType(), cast in features.
 type Command struct {
 	// Metadata
-	Author    *discordgo.User
-	ChannelID Snowflake
-	Type      int
+	Author       *discordgo.User
+	ChannelID    Snowflake
+	Type         int
+	OriginalName string
 
 	// Message data
 	Ballot  *BallotData

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 # This will load the image and then fail due to a bazel bug in argument parsing.
 bazel run --cpu k8 :crbot_image -- --filename "/secret.json" --localhost docker.for.mac.localhost
 

--- a/system_test.go
+++ b/system_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jakevoytko/crbot/app"
 	"github.com/jakevoytko/crbot/feature/help"
 	"github.com/jakevoytko/crbot/feature/learn"
 	"github.com/jakevoytko/crbot/feature/list"
@@ -66,7 +67,7 @@ func TestIntegration(t *testing.T) {
 	runner.SendMessage(testutil.MainChannelID, "?unlearn", learn.MsgHelpUnlearn)
 	runner.SendMessage(testutil.MainChannelID, "?unlearn ", learn.MsgHelpUnlearn)
 	// Can't unlearn in a private channel
-	runner.SendMessage(testutil.DirectMessageID, "?unlearn call", learn.MsgUnlearnMustBePublic)
+	runner.SendMessage(testutil.DirectMessageID, "?unlearn call", fmt.Sprintf(app.MsgPublicOnly, "?unlearn"))
 	// Can't unlearn builtin commands.
 	runner.SendMessage(testutil.MainChannelID, "?unlearn help", fmt.Sprintf(learn.MsgUnlearnFail, "help"))
 	runner.SendMessage(testutil.MainChannelID, "?unlearn learn", fmt.Sprintf(learn.MsgUnlearnFail, "learn"))


### PR DESCRIPTION
The flag is checked by system

- Adds the original command name to the parsed Command to generate the error message
- Adds set -eo pipefail to the run script so it stops on compiler error
- Adds tests for the vote public-only messages, which were previously untested
- Changes ?votestatus to be public-only, since its private channel impl doesn't make sense