### PR TITLE
Add redis config params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 secret.json
 *~
+*.swp
 bazel-*
 *.retry
 .vscode

--- a/config/config.go
+++ b/config/config.go
@@ -22,12 +22,14 @@ type Config struct {
 	RedisDatabase int               `json:"redis_database"`
 }
 
-// SetDefaultConfig sets default values for config params that have them.
-func SetDefaultConfig(config *Config) {
-	config.RedisHost = "localhost"
-	config.RedisPort = 6379
-	config.RedisPassword = ""
-	config.RedisDatabase = 0
+// NewConfig builds a new config and sets default values for config params that have them.
+func NewConfig() Config {
+	return Config{
+		RedisHost:     "localhost",
+		RedisPort:     6379,
+		RedisPassword: "",
+		RedisDatabase: 0,
+	}
 }
 
 // ParseConfig reads the config from the given filename.
@@ -36,8 +38,7 @@ func ParseConfig(filename string) (*Config, error) {
 	if e != nil {
 		return nil, e
 	}
-	var config Config
-	SetDefaultConfig(&config)
+	config := NewConfig()
 	e = json.Unmarshal(f, &config)
 	return &config, e
 }

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,21 @@ import (
 
 // Config represents the JSON format of the config file.
 type Config struct {
-	BotToken string            `json:"bot_token"`
-	RickList []model.Snowflake `json:"ricklist"`
+	BotToken      string            `json:"bot_token"`
+	RickList      []model.Snowflake `json:"ricklist"`
+	RedisHost     string            `json:"redis_host"`
+	RedisPort     int               `json:"redis_port"`
+	RedisUsername string            `json:"redis_username"`
+	RedisPassword string            `json:"redis_password"`
+	RedisDatabase int               `json:"redis_database"`
+}
+
+// SetDefaultConfig sets default values for config params that have them.
+func SetDefaultConfig(config *Config) {
+	config.RedisHost = "localhost"
+	config.RedisPort = 6379
+	config.RedisPassword = ""
+	config.RedisDatabase = 0
 }
 
 // ParseConfig reads the config from the given filename.
@@ -24,6 +37,7 @@ func ParseConfig(filename string) (*Config, error) {
 		return nil, e
 	}
 	var config Config
+	SetDefaultConfig(&config)
 	e = json.Unmarshal(f, &config)
 	return &config, e
 }

--- a/crbot.go
+++ b/crbot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/go-redis/redis/v8"
@@ -25,7 +26,6 @@ import (
 
 func main() {
 	filename := flag.String("filename", "secret.json", "Filename of configuration json")
-	localhost := flag.String("localhost", "localhost", "Configurable localhost hostname, to allow for Docker's weirdness on OSX")
 
 	ctx := context.TODO()
 	flag.Parse()
@@ -38,9 +38,10 @@ func main() {
 
 	// Initialize redis.
 	redisClient := redis.NewClient(&redis.Options{
-		Addr:     *localhost + ":6379",
-		Password: "", // no password set
-		DB:       0,  // use default DB
+		Addr:     config.RedisHost + ":" + strconv.Itoa(config.RedisPort),
+		Username: config.RedisUsername,
+		Password: config.RedisPassword,
+		DB:       config.RedisDatabase,
 	})
 	if _, err := redisClient.Ping(ctx).Result(); err != nil {
 		log.Fatal("Unable to initialize Redis", err)

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -22,5 +22,3 @@ spec:
           args:
             - --filename
             - /secret.json
-            - --localhost
-            - host.docker.internal


### PR DESCRIPTION
Added Redis config options in prep for k8s deployment.

Build is currently failing because of `crbot.go:40:3: unknown field 'Username' in struct literal of type redis.Options`, which is confounding me because it's very clearly (afaik) declared here: https://github.com/go-redis/redis/blob/master/options.go#L48

```shell
$ bazelisk build :crbot
INFO: Analyzed target //:crbot (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /mnt/c/Users/DGMavn/workspace/crbot/BUILD.bazel:27:10: GoCompilePkg crbot.a failed: (Exit 1): builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src crbot.go -arc ... (remaining 27 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: error running subcommand: exit status 2
/home/dgmavn/.cache/bazel/_bazel_dgmavn/64c8599662e990b0a94ca8ac3673a80a/sandbox/linux-sandbox/35/execroot/__main__/crbot.go:40:3: unknown field 'Username' in struct literal of type redis.Options
Target //:crbot failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.221s, Critical Path: 0.05s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```

No updates made to tests yet either.