### PR TITLE
lint/static analysis fixes

### DIFF
--- a/api/remotehastebin.go
+++ b/api/remotehastebin.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -20,10 +20,10 @@ func NewRemoteHastebin() *RemoteHastebin {
 }
 
 const (
-	msgHastebinPostFail     = "Unable to connect to Hastebin service. Give it a few minutes and try again"
-	msgHastebinResponseFail = "Failure reading response from Hastebin service"
-	msgHastebinStatusCode   = "Failed to upload Hastebin :("
-	msgHastebinURLFail      = "Failed getting url from Hastebin service"
+	msgHastebinPostFail     = "unable to connect to Hastebin service. Give it a few minutes and try again"
+	msgHastebinResponseFail = "failure reading response from Hastebin service"
+	msgHastebinStatusCode   = "failed to upload Hastebin :("
+	msgHastebinURLFail      = "failed getting url from Hastebin service"
 )
 
 // Upload uploads the given string to hastebin and returns the URL of the hastebin on success.
@@ -39,7 +39,7 @@ func (g *RemoteHastebin) Upload(contents string) (string, error) {
 
 	if response.StatusCode != 200 {
 		log.Info("Bad status code", errors.New("Code: "+strconv.Itoa(response.StatusCode)))
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		log.Info("Response body: ", errors.New(string(body)))
 		return "", errors.New(msgHastebinStatusCode)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/jakevoytko/crbot/model"
 )
@@ -34,7 +34,7 @@ func NewConfig() Config {
 
 // ParseConfig reads the config from the given filename.
 func ParseConfig(filename string) (*Config, error) {
-	f, e := ioutil.ReadFile(filename)
+	f, e := os.ReadFile(filename)
 	if e != nil {
 		return nil, e
 	}

--- a/feature/learn/customexecutor.go
+++ b/feature/learn/customexecutor.go
@@ -52,7 +52,7 @@ func (e *CustomExecutor) Execute(s api.DiscordSession, channel model.Snowflake, 
 		log.Fatal("Error testing custom feature", err)
 	}
 	if !has {
-		log.Fatal("Accidentally found a mismatched call/response pair", errors.New("Call response mismatch"))
+		log.Fatal("Accidentally found a mismatched call/response pair", errors.New("call response mismatch"))
 	}
 
 	response, err := e.commandMap.Get(command.Custom.Call)

--- a/feature/registry.go
+++ b/feature/registry.go
@@ -37,7 +37,7 @@ func (r *Registry) Register(feature Feature) error {
 	// Register regular parsers.
 	for _, parser := range feature.Parsers() {
 		if _, ok := r.nameToParser[parser.GetName()]; ok {
-			return fmt.Errorf("Duplicate parser: %v", parser.GetName())
+			return fmt.Errorf("duplicate parser: %v", parser.GetName())
 		}
 		if len(parser.GetName()) > 0 {
 			r.nameToParser[parser.GetName()] = parser
@@ -51,7 +51,7 @@ func (r *Registry) Register(feature Feature) error {
 	// Register fallback parser.
 	if fallback := feature.FallbackParser(); fallback != nil {
 		if r.FallbackParser != nil {
-			return errors.New("More than one fallback parser found")
+			return errors.New("more than one fallback parser found")
 		}
 		r.FallbackParser = feature.FallbackParser()
 	}
@@ -59,7 +59,7 @@ func (r *Registry) Register(feature Feature) error {
 	// Register executors.
 	for _, executor := range feature.Executors() {
 		if _, ok := r.typeToExecutor[executor.GetType()]; ok {
-			return fmt.Errorf("Duplicate executor: %v", executor.GetType())
+			return fmt.Errorf("duplicate executor: %v", executor.GetType())
 		}
 		r.typeToExecutor[executor.GetType()] = executor
 	}

--- a/feature/vote/modelhelper.go
+++ b/feature/vote/modelhelper.go
@@ -43,16 +43,16 @@ const (
 )
 
 // ErrorOnlyOneVote indicates that a second vote cannot be started
-var ErrorOnlyOneVote = errors.New("Tried to start vote when one is already active")
+var ErrorOnlyOneVote = errors.New("tried to start vote when one is already active")
 
 // ErrorNoVoteActive indicates that the user can't vote if no vote is active
-var ErrorNoVoteActive = errors.New("Cannot vote when there is no active vote")
+var ErrorNoVoteActive = errors.New("cannot vote when there is no active vote")
 
 // ErrorAlreadyVoted indicates that the user can't vote twice
-var ErrorAlreadyVoted = errors.New("User already voted")
+var ErrorAlreadyVoted = errors.New("user already voted")
 
 // ErrorVoteHasOutcome indicates that the application already set the vote outcome, and to give up
-var ErrorVoteHasOutcome = errors.New("Cannot change vote outcome")
+var ErrorVoteHasOutcome = errors.New("cannot change vote outcome")
 
 // IsVoteActive returns whether there is a most-recent, active vote.
 func (h *ModelHelper) IsVoteActive(channelID model.Snowflake) (bool, error) {

--- a/feature/vote/statusexecutor.go
+++ b/feature/vote/statusexecutor.go
@@ -79,7 +79,8 @@ func (e *StatusExecutor) Execute(s api.DiscordSession, channel model.Snowflake, 
 		log.Fatal("Error pulling most recent vote", err)
 	}
 	if vote == nil {
-		log.Fatal("Nil vote found after vote already active", errors.New("Vote should not be null"))
+		log.Fatal("Nil vote found after vote already active", errors.New("vote should not be null"))
+		return
 	}
 
 	// The below creates a string like this:

--- a/tests/feature/vote/statusutils_test.go
+++ b/tests/feature/vote/statusutils_test.go
@@ -57,7 +57,7 @@ func TestHandleVotesOnInitialLoad_EmptyMap(t *testing.T) {
 	clock.Advance(vote.VoteDuration)
 
 	select {
-	case _, _ = <-commandChannel:
+	case <-commandChannel:
 		t.Errorf("Channel should have been empty")
 	default:
 	}
@@ -80,7 +80,7 @@ func TestHandleVotesOnInitialLoad_HalfDoneVote(t *testing.T) {
 
 	// Assert the channel is now empty.
 	select {
-	case _, _ = <-commandChannel:
+	case <-commandChannel:
 		t.Errorf("Channel should have been empty")
 	default:
 	}
@@ -104,7 +104,7 @@ func TestHandleVotesOnInitialLoad_HalfDoneVote(t *testing.T) {
 
 	// Assert the channel is now empty.
 	select {
-	case _, _ = <-commandChannel:
+	case <-commandChannel:
 		t.Errorf("Channel should have been empty")
 	default:
 	}
@@ -140,7 +140,7 @@ func TestHandleVotesOnInitialLoad_VoteExpired(t *testing.T) {
 
 	// Assert the channel is now empty.
 	select {
-	case _, _ = <-commandChannel:
+	case <-commandChannel:
 		t.Errorf("Channel should have been empty")
 	default:
 	}
@@ -168,7 +168,7 @@ func TestHandleVotesOnInitialLoad_PreviousExpriedVotesDoNotCauseNewConcludes(t *
 
 	// Assert the channel is now empty.
 	select {
-	case _, _ = <-commandChannel:
+	case <-commandChannel:
 		t.Errorf("Channel should have been empty")
 	default:
 	}

--- a/testutil/runner.go
+++ b/testutil/runner.go
@@ -589,7 +589,7 @@ func sendMessage(discordSession api.DiscordSession, handler func(api.DiscordSess
 
 func sendMessageAs(author *discordgo.User, discordSession api.DiscordSession, handler func(api.DiscordSession, *discordgo.MessageCreate), channel model.Snowflake, message string) {
 	editedTimestamp := time.Now()
-	messageCreate := &discordgo.MessageCreate{ // nolint
+	messageCreate := &discordgo.MessageCreate{
 		Message: &discordgo.Message{
 			ID:              "messageID",
 			ChannelID:       channel.Format(),


### PR DESCRIPTION
Lint fixes to make the bad VSCode squigglies go away:

* migrating off of io/ioutil which is apparently deprecated to io and os
* error message un-capitalization
* removing some unnecessary _ assignments
* adding a return after a log.Fatal to resolve some potential nil pointer dereferences (maybe staticcheck thinks log.Fatal could somehow have its panic recovered? idk)
* removed a no-lint directive that didn't seem to do anything anymore